### PR TITLE
Support for more BSDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,12 @@ impl Build {
             _ if target.contains("freebsd") => {
                 config.define("LUA_USE_LINUX", None);
             }
+            _ if target.contains("netbsd") => {
+                config.define("LUA_USE_LINUX", None);
+            }
+            _ if target.contains("openbsd") => {
+                config.define("LUA_USE_LINUX", None);
+            }
             _ if target.contains("apple-darwin") => {
                 match version {
                     Lua51 => config.define("LUA_USE_LINUX", None),


### PR DESCRIPTION
This adds trivial support for more BSD variants: NetBSD and OpenBSD.
