### PR TITLE
Add feature `ucid` for lua54 unicode identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ description = """
 Sources of Lua 5.1/5.2/5.3/5.4 and logic to build them.
 """
 
+[features]
+ucid = [] # accept UniCode IDentifiers
+
 [workspace]
 members = ["testcrate"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ impl Build {
 
         if let Lua54 = version {
             config.define("LUA_COMPAT_5_3", None);
+            #[cfg(feature = "ucid")]
+            config.define("LUA_UCID", None);
         }
 
         if cfg!(debug_assertions) {

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -10,5 +10,6 @@ lua53 = []
 lua52 = []
 lua51 = []
 
-[build-dependencies]
-lua-src = { path = ".." }
+[build-dependencies.lua-src]
+path = ".."
+features = ["ucid"]

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -5,6 +5,7 @@ extern "C" {
     pub fn luaL_openlibs(state: *mut c_void);
     pub fn lua_getfield(state: *mut c_void, index: c_int, k: *const c_char);
     pub fn lua_tolstring(state: *mut c_void, index: c_int, len: *mut c_long) -> *const c_char;
+    pub fn luaL_loadstring(state: *mut c_void, s: *const c_char) -> c_int;
 
     #[cfg(any(feature = "lua52", feature = "lua53", feature = "lua54"))]
     pub fn lua_getglobal(state: *mut c_void, k: *const c_char);
@@ -39,5 +40,18 @@ fn lua_works() {
         assert_eq!(version, "Lua 5.3".as_bytes());
         #[cfg(feature = "lua54")]
         assert_eq!(version, "Lua 5.4".as_bytes());
+    }
+}
+
+#[test]
+fn unicode_identifiers() {
+    unsafe {
+        let state = luaL_newstate();
+        let code = "local 😀 = 0\n";
+        let ret = luaL_loadstring(state, code.as_ptr().cast());
+        #[cfg(feature = "lua54")]
+        assert_eq!(0, ret);
+        #[cfg(not(feature = "lua54"))]
+        assert_ne!(0, ret);
     }
 }

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -47,7 +47,7 @@ fn lua_works() {
 fn unicode_identifiers() {
     unsafe {
         let state = luaL_newstate();
-        let code = "local 😀 = 0\n";
+        let code = "local 😀 = 0\0";
         let ret = luaL_loadstring(state, code.as_ptr().cast());
         #[cfg(feature = "lua54")]
         assert_eq!(0, ret);


### PR DESCRIPTION
Lua 5.4 supports 
[`LUA_UCID`](https://github.com/khvzak/lua-src-rs/blob/master/lua-5.4.3/lctype.c#L20)
compile option
for accept UniCode IDentifiers like emoji and Chinese characters. Here I add a feature named `ucid` for only `lua54` for this.

And I plan to add this feature to `mlua` for my project. Will we have a plan to add more optional Lua features?
