### PR TITLE
Add support for emscripten (wasm)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
           os: macos-latest
         - target: x86_64-pc-windows-msvc
           os: windows-latest
+        - target: wasm32-unknown-emscripten
+          os: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -51,6 +53,12 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y --no-install-recommends gcc-arm-linux-gnueabi libc6-dev-armel-cross
       shell: bash
+    - name: Install emscripten (wasm32-unknown-emscripten)
+      if: ${{ matrix.target == 'wasm32-unknown-emscripten' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends emscripten
+      shell: bash
     - name: Build ${{ matrix.lua }}
       run: |
         cargo build --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} --release --features ${{ matrix.lua }}
@@ -71,11 +79,21 @@ jobs:
           target: x86_64-apple-darwin
         - os: windows-latest
           target: x86_64-pc-windows-msvc
+        - os: ubuntu-latest
+          target: wasm32-unknown-emscripten
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ matrix.target }}
+    - name: Install emscripten (wasm32-unknown-emscripten)
+      if: ${{ matrix.target == 'wasm32-unknown-emscripten' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends emscripten
+        echo 'CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER=node' >> $GITHUB_ENV
+        echo 'RUSTFLAGS="-C link-args=-sERROR_ON_UNDEFINED_SYMBOLS=0"' >> $GITHUB_ENV
+      shell: bash
     - name: Run ${{ matrix.lua }} tests
       run: |
         cargo test --manifest-path testcrate/Cargo.toml --release --features ${{ matrix.lua }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl Build {
         let include_dir = out_dir.join("include");
 
         let source_dir_base = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let source_dir = match version {
+        let mut source_dir = match version {
             Lua51 => source_dir_base.join("lua-5.1.5"),
             Lua52 => source_dir_base.join("lua-5.2.4"),
             Lua53 => source_dir_base.join("lua-5.3.6"),
@@ -105,7 +105,33 @@ impl Build {
                 config.define("LUA_USE_WINDOWS", None);
             }
             _ if target.ends_with("emscripten") => {
-                config.define("LUA_USE_POSIX", None);
+                config
+                    .define("LUA_USE_POSIX", None)
+                    .cpp(true)
+                    .flag("-fexceptions"); // Enable exceptions to be caught
+
+                let cpp_source_dir = out_dir.join("cpp_source");
+                if cpp_source_dir.exists() {
+                    fs::remove_dir_all(&cpp_source_dir).unwrap();
+                }
+                fs::create_dir_all(&cpp_source_dir).unwrap();
+
+                for file in fs::read_dir(&source_dir).unwrap() {
+                    let file = file.unwrap();
+                    let filename = file.file_name().to_string_lossy().to_string();
+                    let src_file = source_dir.join(file.file_name());
+                    let dst_file = cpp_source_dir.join(file.file_name());
+
+                    let mut content = fs::read(src_file).unwrap();
+                    // ljumptab.h only contains definitions and will cause errors when wrapping with
+                    // 'extern "C"'
+                    if filename.ends_with(".h") && !["ljumptab.h"].contains(&filename.as_str()) {
+                        content.splice(0..0, b"extern \"C\" {\n".to_vec());
+                        content.extend(b"\n}".to_vec())
+                    }
+                    fs::write(dst_file, content).unwrap();
+                }
+                source_dir = cpp_source_dir
             }
             _ => panic!("don't know how to build Lua for {}", target),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ impl Build {
                 // Defined in Lua >= 5.3
                 config.define("LUA_USE_WINDOWS", None);
             }
+            _ if target.ends_with("emscripten") => {
+                config.define("LUA_USE_POSIX", None);
+            }
             _ => panic!("don't know how to build Lua for {}", target),
         };
 

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -7,8 +7,10 @@ extern "C" {
     pub fn lua_tolstring(state: *mut c_void, index: c_int, len: *mut c_long) -> *const c_char;
     pub fn luaL_loadstring(state: *mut c_void, s: *const c_char) -> c_int;
 
-    #[cfg(any(feature = "lua52", feature = "lua53", feature = "lua54"))]
+    #[cfg(feature = "lua52")]
     pub fn lua_getglobal(state: *mut c_void, k: *const c_char);
+    #[cfg(any(feature = "lua53", feature = "lua54"))]
+    pub fn lua_getglobal(state: *mut c_void, k: *const c_char) -> c_int;
 }
 
 #[cfg(feature = "lua51")]


### PR DESCRIPTION
This adds support for wasm via the `wasm32-unknown-emscripten` toolchain.

#### Behavioral changes

Given the following lua function:
```c
int lua_getglobal (lua_State *L, const char *name);
```

The following implementation which just works fine on [Tier 1 platforms](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1-with-host-tools) (at least on those I've tested), will cause a linking error when compiling to `wasm32-unknown-emscripten`:
```rust
#[no_mangle]
pub extern "C" fn lua_getglobal(state: *mut c_void, k: *const c_char);
```

If such a mismatch is the case, the linkage will always fails with a "function signature mismatch" error. The `extern "C" fn` must always return the same value as the original C function.
This also applies for the `!` type, for example the [`lua_error`](https://www.lua.org/manual/5.1/manual.html#lua_error) C function returns a `int` although it never actually returns. In Rust, this function could be represented as `pub extern "C" fn lua_error(lua_State *L) -> !` (which is how e.g. [mlua](https://github.com/khvzak/mlua/blob/2022de21564b04a1f13f248d2c77982e1fa1e691/mlua-sys/src/lua51/lua.rs#L231) does it), but the linker also forbids this.

#### Other wasm targets

Because lua uses libc, other wasm targets cannot be targeted natively (atm):
- `wasm32-wasi` has a libc port which is built on top of WASI system calls ([wasi-libc](https://github.com/WebAssembly/wasi-libc)) but this port doesn't fully support all calls lua requires to work. The error I ran into was the [missing setjmp](https://github.com/WebAssembly/wasi-libc/blob/9c17f5235c7977cb2a000990eb8c605a25a80adf/libc-top-half/musl/include/setjmp.h#L44l) call which lua uses to handle errors.
- `wasm32-unknown-unknown` & `wasm64-unknown-unknown` have no libc implementation/wrapper at all.

#### Notes

When testing via `cargo test`, the compilation will fail with "undefined symbol: \<some libc symbol>". The error can be ignored by declaring the env variable `RUSTFLAGS="-C link-args=-sERROR_ON_UNDEFINED_SYMBOLS=0"`. With this set, `testcrate` compiles without issues.

`cargo test` also tries to execute the generated test binary, which is actually just a `.js` file that imports the compiled wasm binary, but this will result in an error. To prevent this, you can set the env variable `CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER="node"` to use nodejs to execute the js file.

The `asmjs-unknown-emscription` toolchain is also supported because it uses the same tools as `wasm32-unknown-emscripten` but as it is considered depreacted in favor of wasm I didn't add any tests for it.