### PR TITLE
Support building for emscripten

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ impl Build {
                 // Defined in Lua >= 5.3
                 config.define("LUA_USE_WINDOWS", None);
             }
+            _ if target.contains("emscripten") => {
+                config.define("LUA_USE_POSIX", None);
+            }
             _ => panic!("don't know how to build Lua for {}", target),
         };
 


### PR DESCRIPTION
Emscripten generally acts like a POSIX system, and building Lua with POSIX features works correctly when targeting emscripten.

This makes it possible to build applications depending on Lua for the wasm32-unknown-emscripten target.