### PR TITLE
Add support for WASI targets to Lua sources

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -1,0 +1,68 @@
+name: 'Setup various CI dependencies'
+inputs:
+  target:
+    description: 'rust target being set up'
+    required: true
+  wasi_sdk:
+    description: 'wasi-sdk version to install'
+    default: 27
+  wasmtime:
+    description: 'wasmtime version to install'
+    default: dev
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        target: ${{ inputs.target }}
+    - run: echo "CARGO_BUILD_TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Install GCC (i686-unknown-linux-gnu)
+      if: ${{ inputs.target == 'i686-unknown-linux-gnu' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends gcc-multilib
+      shell: bash
+    - name: Install GCC (aarch64-unknown-linux-gnu)
+      if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+      shell: bash
+    - name: Install GCC (arm-unknown-linux-gnueabi)
+      if: ${{ inputs.target == 'arm-unknown-linux-gnueabi' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends gcc-arm-linux-gnueabi libc6-dev-armel-cross
+      shell: bash
+    - name: Install GCC (x86_64-pc-windows-gnu)
+      if: ${{ inputs.target == 'x86_64-pc-windows-gnu' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends gcc-mingw-w64-x86-64
+      shell: bash
+    - name: Install emscripten (wasm32-unknown-emscripten)
+      if: ${{ inputs.target == 'wasm32-unknown-emscripten' }}
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends emscripten
+      shell: bash
+
+    - name: Install wasi-sdk/Wasmtime (wasm32-wasip2)
+      if: ${{ inputs.target == 'wasm32-wasip2' }}
+      working-directory: ${{ runner.tool_cache }}
+      run: |
+        curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ inputs.wasi_sdk }}/wasi-sdk-${{ inputs.wasi_sdk }}.0-x86_64-linux.tar.gz
+        tar xf wasi-sdk-${{ inputs.wasi_sdk }}.0-x86_64-linux.tar.gz
+        WASI_SDK_PATH=`pwd`/wasi-sdk-${{ inputs.wasi_sdk }}.0-x86_64-linux
+        echo "WASI_SDK_PATH=$WASI_SDK_PATH" >> $GITHUB_ENV
+        echo "CC_wasm32_wasip2=$WASI_SDK_PATH/bin/clang" >> $GITHUB_ENV
+        echo "CARGO_TARGET_WASM32_WASIP2_LINKER=$WASI_SDK_PATH/bin/clang" >> $GITHUB_ENV
+        echo "CARGO_TARGET_WASM32_WASIP2_RUSTFLAGS=-Clink-arg=-Wl,--export=cabi_realloc" >> $GITHUB_ENV
+
+        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/${{ inputs.wasmtime }}/wasmtime-${{ inputs.wasmtime }}-x86_64-linux.tar.xz
+        tar xf wasmtime-${{ inputs.wasmtime }}-x86_64-linux.tar.xz
+        echo "CARGO_TARGET_WASM32_WASIP2_RUNNER=`pwd`/wasmtime-${{ inputs.wasmtime }}-x86_64-linux/wasmtime -W exceptions" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         - x86_64-pc-windows-gnu
         - x86_64-pc-windows-msvc
         - wasm32-unknown-emscripten
+        - wasm32-wasip2
         lua: [lua54, lua53, lua52, lua51]
         include:
         - target: x86_64-unknown-linux-gnu
@@ -37,44 +38,16 @@ jobs:
           os: windows-latest
         - target: wasm32-unknown-emscripten
           os: ubuntu-latest
+        - target: wasm32-wasip2
+          os: ubuntu-latest
     steps:
     - uses: actions/checkout@main
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: ./.github/actions/setup-deps
       with:
         target: ${{ matrix.target }}
-    - name: Install GCC (i686-unknown-linux-gnu)
-      if: ${{ matrix.target == 'i686-unknown-linux-gnu' }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends gcc-multilib
-      shell: bash
-    - name: Install GCC (aarch64-unknown-linux-gnu)
-      if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-      shell: bash
-    - name: Install GCC (arm-unknown-linux-gnueabi)
-      if: ${{ matrix.target == 'arm-unknown-linux-gnueabi' }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends gcc-arm-linux-gnueabi libc6-dev-armel-cross
-      shell: bash
-    - name: Install GCC (x86_64-pc-windows-gnu)
-      if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends gcc-mingw-w64-x86-64
-      shell: bash
-    - name: Install emscripten (wasm32-unknown-emscripten)
-      if: ${{ matrix.target == 'wasm32-unknown-emscripten' }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends emscripten
-      shell: bash
     - name: Build ${{ matrix.lua }}
       run: |
-        cargo build --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} --release --features ${{ matrix.lua }}
+        cargo build --manifest-path testcrate/Cargo.toml --release --features ${{ matrix.lua }}
       shell: bash
 
   test:
@@ -83,7 +56,11 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        target:
+        - x86_64-unknown-linux-gnu
+        - x86_64-apple-darwin
+        - x86_64-pc-windows-msvc
+        - wasm32-wasip2
         lua: [lua54, lua53, lua52, lua51]
         include:
         - os: ubuntu-latest
@@ -92,9 +69,11 @@ jobs:
           target: x86_64-apple-darwin
         - os: windows-latest
           target: x86_64-pc-windows-msvc
+        - os: ubuntu-latest
+          target: wasm32-wasip2
     steps:
     - uses: actions/checkout@main
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: ./.github/actions/setup-deps
       with:
         target: ${{ matrix.target }}
     - name: Run ${{ matrix.lua }} tests
@@ -103,12 +82,11 @@ jobs:
       shell: bash
 
   test_standalone:
-    name: Test
+    name: Test Standalone
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
@@ -118,35 +96,12 @@ jobs:
           target: x86_64-pc-windows-msvc
     steps:
     - uses: actions/checkout@main
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: ./.github/actions/setup-deps
       with:
         target: ${{ matrix.target }}
     - name: Run standalone tests
       run: |
         cargo test
-
-  test_emscripten:
-    name: Test emscripten
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        lua: [lua54, lua53, lua52, lua51]
-    steps:
-    - uses: actions/checkout@main
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        target: wasm32-unknown-emscripten
-    - name: Install emscripten
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends emscripten
-      shell: bash
-    - name: Run ${{ matrix.lua }} tests
-      run: |
-        export CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER=node
-        cargo test --manifest-path testcrate/Cargo.toml --release --features ${{ matrix.lua }}
-      shell: bash
 
   rustfmt:
     name: Rustfmt

--- a/lua-5.1.5/liolib.c
+++ b/lua-5.1.5/liolib.c
@@ -181,9 +181,13 @@ static int io_popen (lua_State *L) {
 
 
 static int io_tmpfile (lua_State *L) {
+#if !defined(__wasi__)
   FILE **pf = newfile(L);
   *pf = tmpfile();
   return (*pf == NULL) ? pushresult(L, 0, NULL) : 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.1.5/loslib.c
+++ b/lua-5.1.5/loslib.c
@@ -36,8 +36,12 @@ static int os_pushresult (lua_State *L, int i, const char *filename) {
 
 
 static int os_execute (lua_State *L) {
+#if !defined(__wasi__)
   lua_pushinteger(L, system(luaL_optstring(L, 1, NULL)));
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -55,6 +59,7 @@ static int os_rename (lua_State *L) {
 
 
 static int os_tmpname (lua_State *L) {
+#if !defined(__wasi__)
   char buff[LUA_TMPNAMBUFSIZE];
   int err;
   lua_tmpnam(buff, err);
@@ -62,6 +67,9 @@ static int os_tmpname (lua_State *L) {
     return luaL_error(L, "unable to generate a unique filename");
   lua_pushstring(L, buff);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -72,8 +80,12 @@ static int os_getenv (lua_State *L) {
 
 
 static int os_clock (lua_State *L) {
+#if !defined(__wasi__)
   lua_pushnumber(L, ((lua_Number)clock())/(lua_Number)CLOCKS_PER_SEC);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.1.5/luaconf.h
+++ b/lua-5.1.5/luaconf.h
@@ -54,7 +54,9 @@
 #if defined(LUA_USE_POSIX)
 #define LUA_USE_MKSTEMP
 #define LUA_USE_ISATTY
+#if !defined(__wasi__)
 #define LUA_USE_POPEN
+#endif
 #define LUA_USE_ULONGJMP
 #endif
 

--- a/lua-5.2.4/lauxlib.c
+++ b/lua-5.2.4/lauxlib.c
@@ -224,7 +224,7 @@ LUALIB_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
 
 #if !defined(inspectstat)	/* { */
 
-#if defined(LUA_USE_POSIX)
+#if defined(LUA_USE_POSIX) && !defined(__wasi__)
 
 #include <sys/wait.h>
 

--- a/lua-5.2.4/liolib.c
+++ b/lua-5.2.4/liolib.c
@@ -254,9 +254,13 @@ static int io_popen (lua_State *L) {
 
 
 static int io_tmpfile (lua_State *L) {
+#if !defined(__wasi__)
   LStream *p = newfile(L);
   p->f = tmpfile();
   return (p->f == NULL) ? luaL_fileresult(L, 0, NULL) : 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.2.4/loslib.c
+++ b/lua-5.2.4/loslib.c
@@ -78,6 +78,7 @@
 
 
 static int os_execute (lua_State *L) {
+#if !defined(__wasi__)
   const char *cmd = luaL_optstring(L, 1, NULL);
   int stat = system(cmd);
   if (cmd != NULL)
@@ -86,6 +87,9 @@ static int os_execute (lua_State *L) {
     lua_pushboolean(L, stat);  /* true if there is a shell */
     return 1;
   }
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -103,6 +107,7 @@ static int os_rename (lua_State *L) {
 
 
 static int os_tmpname (lua_State *L) {
+#if !defined(__wasi__)
   char buff[LUA_TMPNAMBUFSIZE];
   int err;
   lua_tmpnam(buff, err);
@@ -110,6 +115,9 @@ static int os_tmpname (lua_State *L) {
     return luaL_error(L, "unable to generate a unique filename");
   lua_pushstring(L, buff);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -120,8 +128,12 @@ static int os_getenv (lua_State *L) {
 
 
 static int os_clock (lua_State *L) {
+#if !defined(__wasi__)
   lua_pushnumber(L, ((lua_Number)clock())/(lua_Number)CLOCKS_PER_SEC);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.2.4/luaconf.h
+++ b/lua-5.2.4/luaconf.h
@@ -68,7 +68,9 @@
 #if defined(LUA_USE_POSIX)
 #define LUA_USE_MKSTEMP
 #define LUA_USE_ISATTY
+#if !defined(__wasi__)
 #define LUA_USE_POPEN
+#endif
 #define LUA_USE_ULONGJMP
 #define LUA_USE_GMTIME_R
 #endif

--- a/lua-5.3.6/lauxlib.c
+++ b/lua-5.3.6/lauxlib.c
@@ -251,7 +251,7 @@ LUALIB_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
 
 #if !defined(l_inspectstat)	/* { */
 
-#if defined(LUA_USE_POSIX)
+#if defined(LUA_USE_POSIX) && !defined(__wasi__)
 
 #include <sys/wait.h>
 

--- a/lua-5.3.6/liolib.c
+++ b/lua-5.3.6/liolib.c
@@ -82,7 +82,7 @@ static int l_checkmode (const char *mode) {
 
 #if !defined(l_getc)		/* { */
 
-#if defined(LUA_USE_POSIX)
+#if defined(LUA_USE_POSIX) && !defined(__wasi__)
 #define l_getc(f)		getc_unlocked(f)
 #define l_lockfile(f)		flockfile(f)
 #define l_unlockfile(f)		funlockfile(f)
@@ -267,13 +267,16 @@ static int io_open (lua_State *L) {
 /*
 ** function to close 'popen' files
 */
+#if !defined(__wasi__)
 static int io_pclose (lua_State *L) {
   LStream *p = tolstream(L);
   return luaL_execresult(L, l_pclose(L, p->f));
 }
+#endif
 
 
 static int io_popen (lua_State *L) {
+#if !defined(__wasi__)
   const char *filename = luaL_checkstring(L, 1);
   const char *mode = luaL_optstring(L, 2, "r");
   LStream *p = newprefile(L);
@@ -282,13 +285,20 @@ static int io_popen (lua_State *L) {
   p->f = l_popen(L, filename, mode);
   p->closef = &io_pclose;
   return (p->f == NULL) ? luaL_fileresult(L, 0, filename) : 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
 static int io_tmpfile (lua_State *L) {
+#if !defined(__wasi__)
   LStream *p = newfile(L);
   p->f = tmpfile();
   return (p->f == NULL) ? luaL_fileresult(L, 0, NULL) : 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.3.6/loslib.c
+++ b/lua-5.3.6/loslib.c
@@ -107,6 +107,7 @@ static time_t l_checktime (lua_State *L, int arg) {
 ** ===================================================================
 */
 #if !defined(lua_tmpnam)	/* { */
+#if !defined(__wasi__)	  /* { */
 
 #if defined(LUA_USE_POSIX)	/* { */
 
@@ -131,6 +132,7 @@ static time_t l_checktime (lua_State *L, int arg) {
 #define lua_tmpnam(b,e)		{ e = (tmpnam(b) == NULL); }
 
 #endif				/* } */
+#endif				/* } */
 
 #endif				/* } */
 /* }================================================================== */
@@ -139,6 +141,7 @@ static time_t l_checktime (lua_State *L, int arg) {
 
 
 static int os_execute (lua_State *L) {
+#if !defined(__wasi__)
   const char *cmd = luaL_optstring(L, 1, NULL);
   int stat = system(cmd);
   if (cmd != NULL)
@@ -147,6 +150,9 @@ static int os_execute (lua_State *L) {
     lua_pushboolean(L, stat);  /* true if there is a shell */
     return 1;
   }
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -164,6 +170,7 @@ static int os_rename (lua_State *L) {
 
 
 static int os_tmpname (lua_State *L) {
+#if !defined(__wasi__)
   char buff[LUA_TMPNAMBUFSIZE];
   int err;
   lua_tmpnam(buff, err);
@@ -171,6 +178,9 @@ static int os_tmpname (lua_State *L) {
     return luaL_error(L, "unable to generate a unique filename");
   lua_pushstring(L, buff);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -181,8 +191,12 @@ static int os_getenv (lua_State *L) {
 
 
 static int os_clock (lua_State *L) {
+#if !defined(__wasi__)
   lua_pushnumber(L, ((lua_Number)clock())/(lua_Number)CLOCKS_PER_SEC);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.3.6/ltablib.c
+++ b/lua-5.3.6/ltablib.c
@@ -7,6 +7,10 @@
 #define ltablib_c
 #define LUA_LIB
 
+#if defined(__wasi__)
+#include <stdlib.h>
+#endif
+
 #include "lprefix.h"
 
 
@@ -256,6 +260,9 @@ typedef unsigned int IdxT;
 ** is to copy them to an array of a known type and use the array values.
 */
 static unsigned int l_randomizePivot (void) {
+#if defined(__wasi__)
+  return arc4random();
+#else
   clock_t c = clock();
   time_t t = time(NULL);
   unsigned int buff[sof(c) + sof(t)];
@@ -265,6 +272,7 @@ static unsigned int l_randomizePivot (void) {
   for (i = 0; i < sof(buff); i++)
     rnd += buff[i];
   return rnd;
+#endif
 }
 
 #endif					/* } */

--- a/lua-5.4.8/lauxlib.c
+++ b/lua-5.4.8/lauxlib.c
@@ -265,7 +265,7 @@ LUALIB_API int luaL_fileresult (lua_State *L, int stat, const char *fname) {
 
 #if !defined(l_inspectstat)	/* { */
 
-#if defined(LUA_USE_POSIX)
+#if defined(LUA_USE_POSIX) && !defined(__wasi__)
 
 #include <sys/wait.h>
 

--- a/lua-5.4.8/liolib.c
+++ b/lua-5.4.8/liolib.c
@@ -94,7 +94,7 @@ static int l_checkmode (const char *mode) {
 
 #if !defined(l_getc)		/* { */
 
-#if defined(LUA_USE_POSIX)
+#if defined(LUA_USE_POSIX) && !defined(__wasi__)
 #define l_getc(f)		getc_unlocked(f)
 #define l_lockfile(f)		flockfile(f)
 #define l_unlockfile(f)		funlockfile(f)
@@ -281,14 +281,17 @@ static int io_open (lua_State *L) {
 /*
 ** function to close 'popen' files
 */
+#if !defined(__wasi__)
 static int io_pclose (lua_State *L) {
   LStream *p = tolstream(L);
   errno = 0;
   return luaL_execresult(L, l_pclose(L, p->f));
 }
+#endif
 
 
 static int io_popen (lua_State *L) {
+#if !defined(__wasi__)
   const char *filename = luaL_checkstring(L, 1);
   const char *mode = luaL_optstring(L, 2, "r");
   LStream *p = newprefile(L);
@@ -297,14 +300,21 @@ static int io_popen (lua_State *L) {
   p->f = l_popen(L, filename, mode);
   p->closef = &io_pclose;
   return (p->f == NULL) ? luaL_fileresult(L, 0, filename) : 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
 static int io_tmpfile (lua_State *L) {
+#if !defined(__wasi__)
   LStream *p = newfile(L);
   errno = 0;
   p->f = tmpfile();
   return (p->f == NULL) ? luaL_fileresult(L, 0, NULL) : 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.4.8/loslib.c
+++ b/lua-5.4.8/loslib.c
@@ -100,6 +100,7 @@
 ** ===================================================================
 */
 #if !defined(lua_tmpnam)	/* { */
+#if !defined(__wasi__)	  /* { */
 
 #if defined(LUA_USE_POSIX)	/* { */
 
@@ -124,13 +125,14 @@
 #define lua_tmpnam(b,e)		{ e = (tmpnam(b) == NULL); }
 
 #endif				/* } */
+#endif				/* } */
 
 #endif				/* } */
 /* }================================================================== */
 
 
 #if !defined(l_system)
-#if defined(LUA_USE_IOS)
+#if defined(LUA_USE_IOS) || defined(__wasi__)
 /* Despite claiming to be ISO C, iOS does not implement 'system'. */
 #define l_system(cmd) ((cmd) == NULL ? 0 : -1)
 #else
@@ -169,6 +171,7 @@ static int os_rename (lua_State *L) {
 
 
 static int os_tmpname (lua_State *L) {
+#if !defined(__wasi__)
   char buff[LUA_TMPNAMBUFSIZE];
   int err;
   lua_tmpnam(buff, err);
@@ -176,6 +179,9 @@ static int os_tmpname (lua_State *L) {
     return luaL_error(L, "unable to generate a unique filename");
   lua_pushstring(L, buff);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 
@@ -186,8 +192,12 @@ static int os_getenv (lua_State *L) {
 
 
 static int os_clock (lua_State *L) {
+#if !defined(__wasi__)
   lua_pushnumber(L, ((lua_Number)clock())/(lua_Number)CLOCKS_PER_SEC);
   return 1;
+#else
+  luaL_error(L, "not supported on WASI");
+#endif
 }
 
 

--- a/lua-5.4.8/ltablib.c
+++ b/lua-5.4.8/ltablib.c
@@ -7,6 +7,10 @@
 #define ltablib_c
 #define LUA_LIB
 
+#if defined(__wasi__)
+#include <stdlib.h>
+#endif
+
 #include "lprefix.h"
 
 
@@ -244,6 +248,9 @@ typedef unsigned int IdxT;
 ** is to copy them to an array of a known type and use the array values.
 */
 static unsigned int l_randomizePivot (void) {
+#if defined(__wasi__)
+  return arc4random();
+#else
   clock_t c = clock();
   time_t t = time(NULL);
   unsigned int buff[sof(c) + sof(t)];
@@ -253,6 +260,7 @@ static unsigned int l_randomizePivot (void) {
   for (i = 0; i < sof(buff); i++)
     rnd += buff[i];
   return rnd;
+#endif
 }
 
 #endif					/* } */


### PR DESCRIPTION
This commit is an attempt to work towards mlua-rs/mlua#366 and support WASI targets in the `mlua` crate. This requires that the Lua source code can be compiled to WASI targets such as `wasm32-wasip{1,2}`. The C toolchain used for this is [wasi-sdk] and does not support all that Lua requires out-of-the-box. This necessitates some edits to Lua sources to exclude exposing unsupported functions to scripts.

This additionally updates CI to test the `wasm32-wasip2` target inside of Wasmtime. This currently requires a `dev` release of Wasmtime (builds from `main`) but the Wasmtime 37.0.0 release next week will suffice once it's available due to WebAssembly exception-handling support. I've also dropped the Emscripten tests here as CI wasn't actually testing emscripten (it forgot `--target`) and the tests are otherwise broken if re-enabled. Installation of dependencies on CI has additionally been refactored to a shared "composite" action between the build/test workflows to avoid duplication between them.

[wasi-sdk]: https://github.com/WebAssembly/wasi-sdk