### PR TITLE
fix: add DragonFlyBSD target support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl Build {
             _ if target.contains("linux") => {
                 config.define("LUA_USE_LINUX", None);
             }
-            _ if target.ends_with("bsd") => {
+            _ if target.ends_with("bsd") || target.contains("dragonfly") => {
                 config.define("LUA_USE_LINUX", None);
             }
             _ if target.ends_with("illumos") => {


### PR DESCRIPTION
DragonFly's Rust target triple is `x86_64-unknown-dragonfly` which doesn't end with "bsd", so the existing check missed it. DragonFly is a BSD and uses the same POSIX/Linux-compatible Lua build flags.